### PR TITLE
Laget støtte for rabbitmq-bruker

### DIFF
--- a/charts/helsenorge-application/Chart.yaml
+++ b/charts/helsenorge-application/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
     email: "utv-hn-plattform@norskhelsenett.slack.com"
     url: "https://www.nhn.no/"
 
-version: 0.0.27
+version: 0.0.28
 
 dependencies:
 - name: helsenorge-common

--- a/charts/helsenorge-application/README.md
+++ b/charts/helsenorge-application/README.md
@@ -1,6 +1,6 @@
 # helsenorge-applikasjon
 
-![Version: 0.0.27](https://img.shields.io/badge/Version-0.0.27-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.28](https://img.shields.io/badge/Version-0.0.28-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Helm chart for installere en helsenorge-applikasjon på kuberntes. En helsenorge-applikasjon dekker typene API, WebApp, Service, Batch. Dvs, applikasjoner som utfører arbeid kontinuerlig.
 
@@ -51,9 +51,13 @@ Helm chart for installere en helsenorge-applikasjon på kuberntes. En helsenorge
 | livenessProbe.path | string | `"/api/ping"` | [Liveness probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#types-of-probe) indikerer om containeren kjører ved å gjøre et http kall mot gitt path. |
 | logging | object | `{"areaOvveride":""}` | Logging |
 | nameOverride | string | `""` | Overrider navn på chart. Beholder release-navnet |
-| rabbitmq | object | `{"password":"","user":""}` | Messagings settings - Blir tilgjengeliggjort som environment-variabler i pod |
-| rabbitmq.password | string | `""` | Passord |
-| rabbitmq.user | string | `""` | Bruker |
+| rabbitmq | object | `{"clusterName":"rabbitmq","createUser":true,"password":"","port":5671,"user":"","virtualHost":"internal.messaging.helsenorge.no"}` | Rabbitmq-settings |
+| rabbitmq.clusterName | string | `"rabbitmq"` | Navn på cluster, brukes til å sette opp adressen til rabbitmq, så må være det samme som hostnavnet |
+| rabbitmq.createUser | bool | `true` | Hvis 'true' så opprettes det en rabbitmq-bruker for applikasjonene. Fungerer kun i miljøer der rabbitmq styres av [rabbitmq-topology-operator](https://www.rabbitmq.com/kubernetes/operator/using-topology-operator.html#non-operator).  Hvis satt til false så må 'user' og 'password' settes. |
+| rabbitmq.password | string | `""` | Passord - Brukes kun hvis generate user er satt til 'false' |
+| rabbitmq.port | int | `5671` | Port til amqp-endepunktet til rabbitmq |
+| rabbitmq.user | string | `""` | Bruker - Settes default til det samme som applikasjonen, overstyr det navnet ved å angi en verdi. Eks: configuration-internalapi |
+| rabbitmq.virtualHost | string | `"internal.messaging.helsenorge.no"` | Navn på virtual host |
 | readinessProbe.path | string | `"/health"` | [Readiness probe](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#types-of-probe) indikerer om containeren er klar for å motta requests ved å gjøre et http kall mot gitt path |
 | replicaCount | int | `1` | Antall containere som kjører apiet. Disse lastbalanseres automatisk, men flere containere krever mer ressurser av clusteret. Bør overstyrers i høyere miljøer. |
 | resources | object | Se verdier under | Beskriver hvor mye ressurser en pod som kjører koden skal få tilgang til. Les mer om konseptene [her](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits). |

--- a/charts/helsenorge-application/templates/_helpers.tpl
+++ b/charts/helsenorge-application/templates/_helpers.tpl
@@ -5,5 +5,19 @@ Setter hostname for applikasjonen i ingressen.
 {{ default (printf "%s-%s.%s" (include "common.fullname" .) .Release.Namespace .Values.dnsZone) .Values.ingress.hostname }}
 {{- end }}
 
+{{/*
+Navn på rabbitmq-user for applikasjon
+*/}}
+{{- define "helsenorge-application.rabbitmqUser" -}}
+{{ .Values.rabbitmq.user | default (include "common.fullname" .)  }}
+{{- end }}
+
+{{/*
+Navn på rabbitmq-user secret
+*/}}
+{{- define "helsenorge-application.rabbitmqUserSecret" -}}
+{{ printf "%s-%s" (include "common.fullname" .) "rabbitmq-user" }}
+{{- end }}
+
 
 

--- a/charts/helsenorge-application/templates/deployment.yaml
+++ b/charts/helsenorge-application/templates/deployment.yaml
@@ -45,12 +45,28 @@ spec:
           {{- if .Values.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 12 }}
           {{- end }}  
-          envFrom:
           env:
+          {{- if .Values.rabbitmq.createUser }}
+          - name: HN_InternalMessagingSettings__Credentials__Username
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "helsenorge-application.rabbitmqUserSecret" . }}
+                key: username
+          - name: HN_InternalMessagingSettings__Credentials__Password
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "helsenorge-application.rabbitmqUserSecret" . }}
+                key: password
+          {{- else }}
           - name: HN_InternalMessagingSettings__Credentials__Username
             value: {{ .Values.rabbitmq.user | quote }}
           - name: HN_InternalMessagingSettings__Credentials__Password
             value: {{ .Values.rabbitmq.password | quote }}
+          {{- end }}
+          - name: HN_InternalMessagingSettings__RootAddress
+            value: {{ printf "rabbitmq://%s:%s" .Values.rabbitmq.clusterName .Values.rabbitmq.port}}
+          - name: HN_InternalMessagingSettings__VirtualHost
+            value: {{ .Values.rabbitmq.virtualHost | quote }}
           - name: HN_EhelseSecurityTokenServiceSettings__ClientId
             value: {{ .Values.clientId | quote }}
           - name: HN_EhelseSecurityTokenServiceSettings__ClientSecret

--- a/charts/helsenorge-application/templates/rabbitmq/permissions.yaml
+++ b/charts/helsenorge-application/templates/rabbitmq/permissions.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rabbitmq.createUser }}
+apiVersion: rabbitmq.com/v1beta1
+kind: Permission
+metadata:
+  name: {{ include "common.fullname" . }}
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+spec:
+  vhost: {{ .Values.rabbitmq.virtualHost}}
+  user: {{ include "helsenorge-application.rabbitmqUser" . }}
+  permissions:
+    write: ".*"
+    configure: ".*"
+    read: ".*"
+  rabbitmqClusterReference:
+    name: {{ .Values.rabbitmq.clusterName }}
+{{- end }}

--- a/charts/helsenorge-application/templates/rabbitmq/secret.yaml
+++ b/charts/helsenorge-application/templates/rabbitmq/secret.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.rabbitmq.createUser }}
+apiVersion: v1
+kind: Secret
+metadata:  
+  name: {{ include "helsenorge-application.rabbitmqUserSecret" . }}
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+type: Opaque
+data:
+  username: {{ include "helsenorge-application.rabbitmqUser" . | b64enc }}
+  # try to get the old password
+  # keep in mind, that a dry-run only returns an empty map 
+  {{- $old_password := lookup "v1" "Secret" .Release.Namespace ( include "helsenorge-application.rabbitmqUserSecret" . ) }}
+  # check, if a secret is already set
+  {{- if or (not $old_password) (not $old_password.data) }}
+  # if not set, then generate a new password
+  password: {{ randAlphaNum 20 | b64enc }}
+  {{ else }}
+  # if set, then use the old value
+  password: {{ index $old_password.data "password" }}
+  {{ end }}
+{{- end }}

--- a/charts/helsenorge-application/templates/rabbitmq/user.yaml
+++ b/charts/helsenorge-application/templates/rabbitmq/user.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.rabbitmq.createUser }}
+apiVersion: rabbitmq.com/v1beta1
+kind: User
+metadata:
+  name: {{ include "common.fullname" . }}
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+spec:
+  rabbitmqClusterReference:
+    name: {{ .Values.rabbitmq.clusterName }}
+  importCredentialsSecret:
+    name: {{ include "helsenorge-application.rabbitmqUserSecret" . }}
+{{- end }}

--- a/charts/helsenorge-application/values.yaml
+++ b/charts/helsenorge-application/values.yaml
@@ -16,12 +16,22 @@ clientSecret: ""
 # -- setter ASPNETCORE_ENVIRONMENT environment-variabelen i pod
 aspnetCoreEnvironment: "st"
 
-# -- Messagings settings - Blir tilgjengeliggjort som environment-variabler i pod
+# -- Rabbitmq-settings
 rabbitmq:
-  # -- Bruker
+  # -- Hvis 'true' så opprettes det en rabbitmq-bruker for applikasjonene. Fungerer kun i miljøer der rabbitmq styres av [rabbitmq-topology-operator](https://www.rabbitmq.com/kubernetes/operator/using-topology-operator.html#non-operator). 
+  # Hvis satt til false så må 'user' og 'password' settes.
+  createUser: true
+  # -- Bruker - Settes default til det samme som applikasjonen, overstyr det navnet ved å angi en verdi.
+  # Eks: configuration-internalapi
   user: ""
-  # -- Passord
+  # -- Passord - Brukes kun hvis generate user er satt til 'false'
   password: ""
+  # -- Navn på virtual host
+  virtualHost: internal.messaging.helsenorge.no
+  # -- Navn på cluster, brukes til å sette opp adressen til rabbitmq, så må være det samme som hostnavnet
+  clusterName: rabbitmq
+  # -- Port til amqp-endepunktet til rabbitmq
+  port: 5671
 
 # -- Logging
 logging:


### PR DESCRIPTION
Ved kjøring så kan man spesifisere at man ønsker å opprette en rabbitmq-bruker hvis clusteret støtter dette. Dette igjen krever at clusteret kjører rabbitmq topology operator.